### PR TITLE
Fix auth caching and add missing controllers

### DIFF
--- a/backend/modules/ad-server/models/Campaign.js
+++ b/backend/modules/ad-server/models/Campaign.js
@@ -77,6 +77,19 @@ const Campaign = {
     return result.rows[0];
   },
 
+  async delete(id) {
+    const result = await db.query('DELETE FROM campaigns WHERE id = $1 RETURNING *', [id]);
+    return result.rows[0];
+  },
+
+  async updateStatus(id, status) {
+    const result = await db.query(
+      'UPDATE campaigns SET status = $2, updated_at = CURRENT_TIMESTAMP WHERE id = $1 RETURNING *',
+      [id, status]
+    );
+    return result.rows[0];
+  },
+
   async getPerformanceMetrics(id) {
     const result = await db.query(
       `SELECT

--- a/backend/modules/asset-booking/models/Asset.js
+++ b/backend/modules/asset-booking/models/Asset.js
@@ -49,6 +49,11 @@ const Asset = {
     return result.rows[0];
   },
 
+  async delete(id) {
+    const result = await db.query('DELETE FROM assets WHERE id = $1 RETURNING *', [id]);
+    return result.rows[0];
+  },
+
   // Ad Server Enhancement Methods
   async getAdFormats(id) {
     // TODO: Implement ad formats retrieval

--- a/backend/modules/shared/controllers/userController.js
+++ b/backend/modules/shared/controllers/userController.js
@@ -43,6 +43,62 @@ const UserController = {
       logger.error(err);
       res.status(500).json({ message: 'Error retrieving user' });
     }
+  },
+
+  async update(req, res) {
+    try {
+      const updated = await User.update(req.params.id, req.body);
+      if (!updated) return res.status(404).json({ message: 'User not found' });
+      res.json(updated);
+    } catch (err) {
+      logger.error(err);
+      res.status(500).json({ message: 'Failed to update user' });
+    }
+  },
+
+  async delete(req, res) {
+    try {
+      const deleted = await User.delete(req.params.id);
+      if (!deleted) return res.status(404).json({ message: 'User not found' });
+      res.json({ message: 'User deleted' });
+    } catch (err) {
+      logger.error(err);
+      res.status(500).json({ message: 'Failed to delete user' });
+    }
+  },
+
+  async getUserRoles(req, res) {
+    try {
+      const roles = await User.getUserRoles(req.params.id);
+      res.json(roles);
+    } catch (err) {
+      logger.error(err);
+      res.status(500).json({ message: 'Failed to get user roles' });
+    }
+  },
+
+  async assignRole(req, res) {
+    const { role_id, organization_id } = req.body;
+    try {
+      const result = await User.assignRole(req.params.id, role_id, organization_id);
+      res.status(201).json(result);
+    } catch (err) {
+      logger.error(err);
+      res.status(500).json({ message: 'Failed to assign role' });
+    }
+  },
+
+  async removeRole(req, res) {
+    const { roleId } = req.params;
+    const { organization_id } = req.body;
+    try {
+      const result = await User.removeRole(req.params.id, roleId, organization_id);
+      if (!result) return res.status(404).json({ message: 'Role not found' });
+      res.json(result);
+    } catch (err) {
+      logger.error(err);
+      res.status(500).json({ message: 'Failed to remove role' });
+    }
   }
 };
 


### PR DESCRIPTION
## Summary
- fix response caching to read JWT before caching
- implement user management controller actions
- add delete method to Asset model and controller
- add delete and status endpoints for campaigns
- adjust bidding controller for test environment
- add delete and status model functions for Campaigns

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_b_688b295d43c88323901d59436e99f07e