### PR TITLE
feat: add CTR model training and bandit scoring

### DIFF
--- a/backend/__tests__/utils/mlEngine.test.js
+++ b/backend/__tests__/utils/mlEngine.test.js
@@ -1,6 +1,11 @@
 const MLEngine = require('../../modules/ad-server/utils/mlEngine');
 
 describe('MLEngine', () => {
+  beforeEach(() => {
+    // Reset model between tests to ensure isolation
+    MLEngine.ctrModel = null;
+  });
+
   describe('predictCTR', () => {
     it('boosts CTR for premium location', async () => {
       const creative = { performance: { ctr: 0.02 } };
@@ -18,15 +23,34 @@ describe('MLEngine', () => {
     });
   });
 
-  describe('optimizeCreativeSelection', () => {
-    it('returns creative with highest score', async () => {
-      const creatives = [
-        { id: 1, performance: { ctr: 0.01 } },
-        { id: 2, performance: { ctr: 0.03 } }
+  describe('trainCTRModel', () => {
+    it('learns to prefer higher performing creatives', async () => {
+      const data = [
+        { creative: { performance: { ctr: 0.01 } }, user: {}, context: {}, label: 0 },
+        { creative: { performance: { ctr: 0.05 } }, user: {}, context: {}, label: 1 }
       ];
-      const user_context = { location: { country: 'US' } };
-      const best = await MLEngine.optimizeCreativeSelection(creatives, user_context);
+      MLEngine.trainCTRModel(data);
+
+      const low = await MLEngine.predictCTR({ performance: { ctr: 0.01 } }, {}, {});
+      const high = await MLEngine.predictCTR({ performance: { ctr: 0.05 } }, {}, {});
+      expect(high).toBeGreaterThan(low);
+    });
+  });
+
+  describe('optimizeCreativeSelection', () => {
+    it('uses Thompson Sampling to select creative', async () => {
+      // Deterministic sampling
+      jest.spyOn(Math, 'random').mockReturnValue(0.5);
+
+      const creatives = [
+        { id: 1, performance: { ctr: 0.01, clicks: 5, impressions: 50 } },
+        { id: 2, performance: { ctr: 0.03, clicks: 15, impressions: 50 } }
+      ];
+
+      const best = await MLEngine.optimizeCreativeSelection(creatives, {}, {});
       expect(best.id).toBe(2);
+
+      Math.random.mockRestore();
     });
   });
 });

--- a/backend/modules/ad-server/utils/adServer.js
+++ b/backend/modules/ad-server/utils/adServer.js
@@ -40,7 +40,7 @@ const AdServer = {
       }
 
       // 3. Use ML engine to score creatives
-      const mlCreative = await MLEngine.optimizeCreativeSelection(targetedCreatives, user_context);
+      const mlCreative = await MLEngine.optimizeCreativeSelection(targetedCreatives, user_context, page_context);
 
       // 4. Apply performance optimization as fallback
       const bestCreative = await this.selectBestCreative([mlCreative], user_context);

--- a/backend/modules/ad-server/utils/mlEngine.js
+++ b/backend/modules/ad-server/utils/mlEngine.js
@@ -1,45 +1,147 @@
 const logger = require('../../shared/utils/logger');
+const { beta } = require('jstat');
+
+/**
+ * Simple logistic regression implementation using gradient descent.
+ * This keeps dependencies minimal while allowing us to train a model
+ * on historical user/asset/context features.
+ */
+class LogisticRegression {
+  constructor() {
+    this.weights = null; // includes bias term as weight[0]
+  }
+
+  train(X, y, options = {}) {
+    const epochs = options.epochs || 200;
+    const lr = options.learningRate || 0.1;
+    const n = X[0].length;
+    this.weights = new Array(n + 1).fill(0); // bias + weights
+
+    for (let epoch = 0; epoch < epochs; epoch++) {
+      for (let i = 0; i < X.length; i++) {
+        const features = [1, ...X[i]]; // prepend bias
+        let z = 0;
+        for (let j = 0; j < features.length; j++) {
+          z += this.weights[j] * features[j];
+        }
+        const pred = 1 / (1 + Math.exp(-z));
+        const error = y[i] - pred;
+        // update
+        for (let j = 0; j < features.length; j++) {
+          this.weights[j] += lr * error * features[j];
+        }
+      }
+    }
+  }
+
+  predict(x) {
+    if (!this.weights) return 0.5;
+    const features = [1, ...x];
+    let z = 0;
+    for (let j = 0; j < features.length; j++) {
+      z += this.weights[j] * features[j];
+    }
+    return 1 / (1 + Math.exp(-z));
+  }
+}
+
+/**
+ * Convert creative/user/context objects into a numeric feature vector
+ * for the CTR model. In production this would be far more extensive
+ * and handle categorical encoding, missing values, etc.
+ */
+function extractFeatures(creative = {}, user = {}, context = {}) {
+  return [
+    creative.performance && creative.performance.ctr ? creative.performance.ctr : 0,
+    creative.performance && creative.performance.revenue_per_view
+      ? creative.performance.revenue_per_view
+      : 0,
+    creative.bid_price || 0,
+    user.recency || 0,
+    user.purchase_history || 0,
+    context.screen === 'home' ? 1 : 0,
+    context.device === 'mobile' ? 1 : 0
+  ];
+}
 
 const MLEngine = {
-  async predictCTR(creative, user_context, page_context) {
-    // Simple CTR prediction based on historical data
-    // In production, this would use a trained ML model
+  ctrModel: null,
 
+  /**
+   * Train a logistic regression model on provided data.
+   * Each datum should contain: { creative, user, context, label }
+   */
+  trainCTRModel(trainingData = []) {
+    try {
+      const X = trainingData.map(d => extractFeatures(d.creative, d.user, d.context));
+      const y = trainingData.map(d => d.label);
+      const model = new LogisticRegression();
+      model.train(X, y);
+      this.ctrModel = model;
+    } catch (err) {
+      logger.error('Error training CTR model', { error: err.message });
+      this.ctrModel = null;
+    }
+  },
+
+  /**
+   * Predict CTR using the trained model if available; otherwise fall back
+   * to heuristic scoring based on creative/user/page context.
+   */
+  async predictCTR(creative = {}, user_context = {}, page_context = {}) {
+    if (this.ctrModel) {
+      const features = extractFeatures(creative, user_context, page_context);
+      return this.ctrModel.predict(features);
+    }
+
+    // Heuristic fallback
     let baseCTR = 0.015; // 1.5% base CTR
 
-    // Adjust based on creative performance
     if (creative.performance && creative.performance.ctr) {
       baseCTR = creative.performance.ctr;
     }
 
-    // Adjust based on user context
     if (user_context.location && ['US', 'CA'].includes(user_context.location.country)) {
-      baseCTR *= 1.2; // Premium location boost
+      baseCTR *= 1.2;
     }
 
-    // Adjust based on page context
     if (page_context && page_context.category === 'healthcare') {
-      baseCTR *= 1.1; // Healthcare category boost
+      baseCTR *= 1.1;
     }
 
-    return Math.min(baseCTR, 0.05); // Cap at 5%
+    return Math.min(baseCTR, 0.05);
   },
 
-  async optimizeCreativeSelection(creatives, user_context) {
-    // Score creatives based on ML predictions
-    const scoredCreatives = await Promise.all(
-      creatives.map(async (creative) => {
-        const predictedCTR = await this.predictCTR(creative, user_context);
-        return {
-          ...creative,
-          score: predictedCTR * 1000 // Convert to score
-        };
+  /**
+   * Sample from a Beta distribution for Thompson Sampling.
+   */
+  sampleBeta(alpha, betaParam) {
+    return beta.sample(alpha, betaParam);
+  },
+
+  /**
+   * Select the best creative using Thompson Sampling for exploration.
+   */
+  async optimizeCreativeSelection(creatives, user_context = {}, page_context = {}) {
+    const scored = await Promise.all(
+      creatives.map(async creative => {
+        const predicted = await this.predictCTR(creative, user_context, page_context);
+        const clicks = creative.performance && creative.performance.clicks
+          ? creative.performance.clicks
+          : 0;
+        const impressions = creative.performance && (creative.performance.impressions || creative.performance.views)
+          ? (creative.performance.impressions || creative.performance.views)
+          : 0;
+        const alpha = 1 + clicks + predicted * 10;
+        const betaParam = 1 + Math.max(impressions - clicks, 0) + (1 - predicted) * 10;
+        const score = this.sampleBeta(alpha, betaParam);
+        return { creative, score };
       })
     );
 
-    // Return highest scoring creative
-    return scoredCreatives.sort((a, b) => b.score - a.score)[0];
+    return scored.sort((a, b) => b.score - a.score)[0].creative;
   }
 };
 
 module.exports = MLEngine;
+

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -18,6 +18,7 @@
         "express": "^4.18.2",
         "express-rate-limit": "^6.7.0",
         "jsonwebtoken": "^9.0.0",
+        "jstat": "^1.9.6",
         "pg": "^8.11.0",
         "redis": "^4.7.1",
         "winston": "^3.8.2",
@@ -3744,6 +3745,11 @@
         "node": ">=12",
         "npm": ">=6"
       }
+    },
+    "node_modules/jstat": {
+      "version": "1.9.6",
+      "resolved": "https://registry.npmjs.org/jstat/-/jstat-1.9.6.tgz",
+      "integrity": "sha512-rPBkJbK2TnA8pzs93QcDDPlKcrtZWuuCo2dVR0TFLOJSxhqfWOVCSp8aV3/oSbn+4uY4yw1URtLpHQedtmXfug=="
     },
     "node_modules/jwa": {
       "version": "1.4.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -25,7 +25,8 @@
     "pg": "^8.11.0",
     "redis": "^4.7.1",
     "winston": "^3.8.2",
-    "winston-daily-rotate-file": "^4.7.1"
+    "winston-daily-rotate-file": "^4.7.1",
+    "jstat": "^1.9.6"
   },
   "devDependencies": {
     "@types/jest": "^29.5.2",


### PR DESCRIPTION
## Summary
- add logistic regression CTR model with feature extraction
- integrate Thompson Sampling bandit and pass page context for scoring
- verify model via unit tests and add jstat dependency

## Testing
- `npm test` *(fails: connect ECONNREFUSED ::1:5435)*

------
https://chatgpt.com/codex/tasks/task_b_688eec56c2a48323953e9a5e8e28dad0