### PR TITLE
feat: add basic experimentation framework

### DIFF
--- a/backend/modules/experimentation/__tests__/experiment.test.js
+++ b/backend/modules/experimentation/__tests__/experiment.test.js
@@ -1,0 +1,44 @@
+const Experiment = require('../utils/experiment');
+
+describe('Experiment', () => {
+  test('tracks metrics for a variant', () => {
+    const exp = new Experiment('ab', {
+      baselineByCohort: { default: 'control' },
+      variants: {
+        control: {
+          ranking: 'baseline',
+          biddingStrategy: 'standard',
+          modelVersion: 'v1'
+        },
+        variantA: {
+          ranking: 'new',
+          biddingStrategy: 'aggressive',
+          modelVersion: 'v2'
+        }
+      }
+    });
+
+    // record events
+    exp.recordImpression('variantA', 2);
+    exp.recordImpression('variantA', 3);
+    exp.recordClick('variantA');
+    exp.recordConversion('variantA');
+
+    const metrics = exp.getMetrics('variantA');
+    expect(metrics.revenuePerImpression).toBeCloseTo(2.5);
+    expect(metrics.ctr).toBeCloseTo(0.5);
+    expect(metrics.conversionRate).toBeCloseTo(1);
+  });
+
+  test('allows updating variant configuration', () => {
+    const exp = new Experiment('ab', {
+      variants: {
+        B: { ranking: 'alt', biddingStrategy: 'balanced', modelVersion: 'v1' }
+      }
+    });
+
+    expect(exp.getVariantConfig('B').modelVersion).toBe('v1');
+    exp.setVariantConfig('B', { modelVersion: 'v2' });
+    expect(exp.getVariantConfig('B').modelVersion).toBe('v2');
+  });
+});

--- a/backend/modules/experimentation/index.js
+++ b/backend/modules/experimentation/index.js
@@ -1,0 +1,5 @@
+const Experiment = require('./utils/experiment');
+
+module.exports = {
+  Experiment
+};

--- a/backend/modules/experimentation/utils/experiment.js
+++ b/backend/modules/experimentation/utils/experiment.js
@@ -1,0 +1,82 @@
+class Experiment {
+  constructor(name, { baselineByCohort = {}, variants = {} } = {}) {
+    this.name = name;
+    this.baselineByCohort = baselineByCohort;
+    this.variants = variants;
+    this.metrics = {};
+
+    const register = (variant) => {
+      if (!this.metrics[variant]) {
+        this.metrics[variant] = {
+          impressions: 0,
+          revenue: 0,
+          clicks: 0,
+          conversions: 0
+        };
+      }
+    };
+
+    Object.keys(variants).forEach(register);
+    Object.values(baselineByCohort).forEach(register);
+  }
+
+  assign(cohort) {
+    if (cohort && this.baselineByCohort[cohort]) {
+      return this.baselineByCohort[cohort];
+    }
+    const names = Object.keys(this.variants);
+    if (names.length === 0) return null;
+    const index = Math.floor(Math.random() * names.length);
+    return names[index];
+  }
+
+  _ensure(variant) {
+    if (!this.metrics[variant]) {
+      this.metrics[variant] = {
+        impressions: 0,
+        revenue: 0,
+        clicks: 0,
+        conversions: 0
+      };
+    }
+  }
+
+  recordImpression(variant, revenue = 0) {
+    this._ensure(variant);
+    this.metrics[variant].impressions += 1;
+    this.metrics[variant].revenue += revenue;
+  }
+
+  recordClick(variant) {
+    this._ensure(variant);
+    this.metrics[variant].clicks += 1;
+  }
+
+  recordConversion(variant) {
+    this._ensure(variant);
+    this.metrics[variant].conversions += 1;
+  }
+
+  getMetrics(variant) {
+    this._ensure(variant);
+    const data = this.metrics[variant];
+    const revenuePerImpression = data.impressions ? data.revenue / data.impressions : 0;
+    const ctr = data.impressions ? data.clicks / data.impressions : 0;
+    const conversionRate = data.clicks ? data.conversions / data.clicks : 0;
+    return {
+      revenuePerImpression,
+      ctr,
+      conversionRate
+    };
+  }
+
+  getVariantConfig(variant) {
+    return this.variants[variant];
+  }
+
+  setVariantConfig(variant, config) {
+    this.variants[variant] = { ...(this.variants[variant] || {}), ...config };
+  }
+}
+
+module.exports = Experiment;


### PR DESCRIPTION
## Summary
- add Experiment utility for cohort-based A/B tests with variant-level metrics
- support variant configurations for ranking, bidding, and model versions
- cover metrics and configuration updates with tests

## Testing
- `npm test` (fails: ECONNREFUSED ::1:5435)


------
https://chatgpt.com/codex/tasks/task_b_68942ceb8d6483239fb0b24fa2b87988